### PR TITLE
[Server] Add UseMiddlewares function to server package.

### DIFF
--- a/server/middleware.go
+++ b/server/middleware.go
@@ -1,0 +1,21 @@
+package server
+
+import (
+	"sync"
+
+	"github.com/mwm-io/gapi/handler"
+	"github.com/mwm-io/gapi/middleware"
+)
+
+var middlewareMU sync.Mutex
+
+// UseMiddlewares appends a given list of handler.Middleware to middlewares chain.
+//
+// Middleware can be used to intercept or otherwise modify requests and/or responses, and
+// are executed in list order.
+func UseMiddlewares(middlewares ...handler.Middleware) {
+	middlewareMU.Lock()
+	defer middlewareMU.Unlock()
+
+	middleware.Defaults = append(middleware.Defaults, middlewares...)
+}


### PR DESCRIPTION
## Proposal

Add a new callback to `server` package: `UseMiddlewares()`

Developper can globally append a list of middleware to server.

```go
func main() {
	r := server.NewMux()

	server.UseMiddlewares(MyCustomMiddleware{}, MySecondCustomMiddleware{})

	server.AddHandlerFactory(r, http.MethodGet, "/hello", NewHelloHandler)

	gLog.Info("Starting http server")
	if err := server.ServeAndHandleShutdown(r); err != nil {
		gLog.Emergency(err)
	}

	gLog.Info("Server stopped")
}
```