### PR TITLE
[Server] Add WithErrorBuilders option to gapi server.

### DIFF
--- a/errors/builder.go
+++ b/errors/builder.go
@@ -1,0 +1,27 @@
+package errors
+
+import (
+	"sync"
+)
+
+var (
+	// errorBuilders slice contains all custom ErrorBuilder callbacks.
+	// You can update this list if you want to change ErrorBuilder callbacks
+	// for all you handlers.
+	errorBuilders []ErrorBuilder
+
+	// addErrorBuildersMU is a sync.Mutex used by AddErrorBuilders.
+	addErrorBuildersMU sync.Mutex
+)
+
+// ErrorBuilder is a callback that transform the given error to a gapi Error.
+type ErrorBuilder func(err error) Error
+
+// AddErrorBuilders appends custom errors.ErrorBuilder.
+// These callbacks are executed when wrapping an error with errors.Wrap().
+func AddErrorBuilders(builders ...ErrorBuilder) {
+	addErrorBuildersMU.Lock()
+	defer addErrorBuildersMU.Unlock()
+
+	errorBuilders = append(errorBuilders, builders...)
+}

--- a/errors/error.go
+++ b/errors/error.go
@@ -41,6 +41,12 @@ func Wrap(err error) Error {
 		return nil
 	}
 
+	for _, builder := range errorBuilders {
+		if gErr := builder(err); gErr != nil {
+			return gErr
+		}
+	}
+
 	newErr := &FullError{
 		userMessage:  err.Error(),
 		kind:         "",


### PR DESCRIPTION
Add a new server option to append custom error builder callbacks.

Those callbacks are executed when calling `errors.Wrap()`.