### PR TITLE
Dr/add with operation

### DIFF
--- a/openapi/builder.go
+++ b/openapi/builder.go
@@ -6,6 +6,7 @@ import (
 	"github.com/swaggest/openapi-go/openapi3"
 
 	"github.com/mwm-io/gapi/errors"
+	"github.com/mwm-io/gapi/utils"
 )
 
 // DocBuilder is a builder to simplify the documentation of an operation
@@ -64,6 +65,8 @@ func (b *DocBuilder) Error() error {
 // WithSummary set a Summary (Title) to the operation
 func (b *DocBuilder) WithSummary(summary string) *DocBuilder {
 	b.operation.WithSummary(summary)
+	defaultOperationID := utils.GenerateOperationID("/" + b.httpMethod + b.path)
+	b.operation.ID = &defaultOperationID
 	return b
 }
 
@@ -237,5 +240,11 @@ func (b *DocBuilder) WithError(statusCode int, kind, message string, options ...
 
 	b.operation.Responses.WithMapOfResponseOrRefValuesItem(statusCodeStr, resp)
 
+	return b
+}
+
+// WithOperationID set an operationID to the operation
+func (b *DocBuilder) WithOperationID(operationID string) *DocBuilder {
+	b.operation.ID = &operationID
 	return b
 }

--- a/utils/path_formatting.go
+++ b/utils/path_formatting.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+)
+
+func toTitleCase(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+func GenerateOperationID(path string) string {
+	re := regexp.MustCompile(`{([^}]+)}`)
+	path = re.ReplaceAllString(path, "")
+
+	pathParts := strings.Split(path, "/")
+	for i, part := range pathParts {
+		if part != "" {
+			pathParts[i] = toTitleCase(strings.ToLower(part))
+		}
+	}
+	operationID := strings.Join(pathParts, "")
+
+	operationID = strings.ReplaceAll(operationID, "-", "")
+	operationID = strings.ReplaceAll(operationID, "/", "")
+	operationID = strings.ReplaceAll(operationID, "_", "")
+	operationID = strings.ToLower(operationID[:1]) + operationID[1:]
+
+	return operationID
+}


### PR DESCRIPTION
Add WithOperation method that sets an operationID.
In case to have always an operationID I added in the WithSummary, which is always used a default generation of operation ID using the path endpoint.
Examples :

Path = /state
OperationID = state

Path = /anonymous/register
OperationID = anonymousRegister

Path = /mail/register
OperationID = mailRegister

Path = /mail/login
OperationID = mailLogin

Path = /mail/password
OperationID = mailPassword

Path = /mail/reset-password/request
OperationID = mailResetpasswordRequest

Path = /mail/reset-password/submit
OperationID = mailResetpasswordSubmit

Path = /mail/confirmation/request
OperationID = mailConfirmationRequest

Path = /mail/confirmation/submit
OperationID = mailConfirmationSubmit

Path = /mail/connection-code/request
OperationID = mailConnectioncodeRequest

Path = /connection-code/submit
OperationID = connectioncodeSubmit

Path = /token/refresh
OperationID = tokenRefresh

Path = /logout
OperationID = logout

Path = /provider/{provider}/redirect
OperationID = providerRedirect

Path = /provider/{provider}/code
OperationID = providerCode

Path = /provider/{provider}/token
OperationID = providerToken

Path = /provider/apple/code
OperationID = providerAppleCode

Path = /delete
OperationID = delete

Path = /clients/{clientID}/apps
OperationID = clientsApps

Path = /invalidate-token
OperationID = invalidatetoken
